### PR TITLE
Remove color from SVG file to be able to customize it

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ module.exports = {
 };
 ```
 
-...or if you are using [Expo](https://expo.io/), in `app.json`:
+...or if you are using [Expo](https://expo.io/), in `app.json`):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ You can then use your image as a component:
 
 _If you use React Native version 0.56 or older, you need to rename your `.svg` files to `.svgx`._
 
+### Color override
+
+You can override the color defined in SVG input file in your React component.
+For this, you can use the component like this:
+
+```
+<Logo color="#000000" />
+```
+
+And change your `rn-cli.config.js` file to use `without-color.js` file instead of `index.js`.
+
 ### Demo (iOS/Android/Web)
 
 - [react-native-svg-example](https://github.com/kristerkari/react-native-svg-example)
@@ -41,6 +52,8 @@ yarn add --dev react-native-svg-transformer
 ```
 
 ### Step 3: Configure the react native packager
+
+_If you need to remove the color defined in SVG files, use `without-color.js` instead of `index.js`._
 
 #### For React Native v0.57 or newer
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function xmlnsSvgToXmlns(svgrOutput) {
 }
 
 function removeColor(svgrOutput) {
-  return svgrOutput.replace(/fill=\"([#0-9a-fA-F]+)\"/gi, '');
+  return svgrOutput.replace(/fill="([#0-9a-fA-F]+)"/gi, "");
 }
 
 function fixRenderingBugs(svgrOutput) {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,10 @@ function xmlnsSvgToXmlns(svgrOutput) {
   return svgrOutput.replace(/xmlns:svg=/gi, "xmlns=");
 }
 
+function removeColor(svgrOutput) {
+  return svgrOutput.replace(/fill=\"([#0-9a-fA-F]+)\"/gi, '');
+}
+
 function fixRenderingBugs(svgrOutput) {
   return xmlnsSvgToXmlns(xlinkHrefToHref(svgrOutput));
 }
@@ -44,6 +48,10 @@ module.exports.transform = function(src, filename, options) {
 
   if (filename.endsWith(".svg") || filename.endsWith(".svgx")) {
     var jsCode = svgr.sync(src, { native: true });
+    if (options.removeSvgColor) {
+      delete options.removeSvgColor;
+      jsCode = removeColor(jsCode);
+    }
     return upstreamTransformer.transform({
       src: fixRenderingBugs(jsCode),
       filename,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "files": [
     "index.js",
+    "without-color.js",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/without-color.js
+++ b/without-color.js
@@ -1,4 +1,4 @@
-var defaultTransformer = require('.');
+var defaultTransformer = require(".");
 
 module.exports.transform = function(src, filename, options) {
   if (typeof src === "object") {

--- a/without-color.js
+++ b/without-color.js
@@ -1,0 +1,18 @@
+var defaultTransformer = require('.');
+
+module.exports.transform = function(src, filename, options) {
+  if (typeof src === "object") {
+    // handle RN >= 0.46
+    ({ src, filename, options } = src);
+  }
+
+  if (options) {
+    options.removeSvgColor = true;
+  } else {
+    options = {
+      removeSvgColor: true
+    };
+  }
+
+  return defaultTransformer.transform(src, filename, options);
+};


### PR DESCRIPTION
This PR adds ability to remove colors from SVG files to be able to define it in React components like this:

## Usage

```
<Bulb width={32} height={32} fill="#00ff00" />
```

## With default transformer

<img width="33" alt="capture d ecran 2018-12-12 a 16 22 54" src="https://user-images.githubusercontent.com/8419208/49879448-4be23e80-fe2a-11e8-9567-5ae2d626fc9a.png">

## With color removal

<img width="34" alt="capture d ecran 2018-12-12 a 16 24 56" src="https://user-images.githubusercontent.com/8419208/49879556-821fbe00-fe2a-11e8-8bcf-68144ff1fcc9.png">
