### PR TITLE
update for expo 35

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ yarn add --dev react-native-svg-transformer
 
 ### Step 3: Configure the react native packager
 
+#### For Expo SDK v35.0.0 or newer
+If you are using [Expo](https://expo.io/) v35.0.0, you also need to add "ts" and "tsx" in sourceExts on `app.json`:
+
+```json
+{
+  "expo": {
+    "packagerOpts": {
+      "config": "metro.config.js",
+      "sourceExts": ["js", "jsx", "ts", "tsx", "svg"]
+    }
+  }
+}
+```
+
+---
+
 #### For React Native v0.57 or newer / Expo SDK v31.0.0 or newer
 
 Merge the contents from your project's `metro.config.js` file with this config (create the file if it does not exist already).
@@ -67,6 +83,21 @@ module.exports = (async () => {
 })();
 ```
 
+##### For Expo SDK v35.0.0 or newer
+If you are using [Expo](https://expo.io/) v35.0.0, you also need to add "ts" and "tsx" in sourceExts on `app.json`:
+
+```json
+{
+  "expo": {
+    "packagerOpts": {
+      "config": "metro.config.js",
+      "sourceExts": ["js", "jsx", "ts", "tsx", "svg"]
+    }
+  }
+}
+```
+
+##### For Expo SDK v31.0.0 or newer
 If you are using [Expo](https://expo.io/), you also need to add this to `app.json`:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -42,22 +42,6 @@ yarn add --dev react-native-svg-transformer
 
 ### Step 3: Configure the react native packager
 
-#### For Expo SDK v35.0.0 or newer
-If you are using [Expo](https://expo.io/) v35.0.0, you also need to add "ts" and "tsx" in sourceExts on `app.json`:
-
-```json
-{
-  "expo": {
-    "packagerOpts": {
-      "config": "metro.config.js",
-      "sourceExts": ["js", "jsx", "ts", "tsx", "svg"]
-    }
-  }
-}
-```
-
----
-
 #### For React Native v0.57 or newer / Expo SDK v31.0.0 or newer
 
 Merge the contents from your project's `metro.config.js` file with this config (create the file if it does not exist already).

--- a/README.md
+++ b/README.md
@@ -67,21 +67,6 @@ module.exports = (async () => {
 })();
 ```
 
-##### For Expo SDK v35.0.0 or newer
-If you are using [Expo](https://expo.io/) v35.0.0, you also need to add "ts" and "tsx" in sourceExts on `app.json`:
-
-```json
-{
-  "expo": {
-    "packagerOpts": {
-      "config": "metro.config.js",
-      "sourceExts": ["js", "jsx", "ts", "tsx", "svg"]
-    }
-  }
-}
-```
-
-##### For Expo SDK v31.0.0 or newer
 If you are using [Expo](https://expo.io/), you also need to add this to `app.json`:
 
 ```json
@@ -89,7 +74,7 @@ If you are using [Expo](https://expo.io/), you also need to add this to `app.jso
   "expo": {
     "packagerOpts": {
       "config": "metro.config.js",
-      "sourceExts": ["js", "jsx", "svg"]
+      "sourceExts": ["js", "jsx", "ts", "tsx", "svg"]
     }
   }
 }


### PR DESCRIPTION
Since expo 35, we have to add ts and tsx in packagerOpts's sourceExts.