### PR TITLE
Support svgr config location based on asset path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var semver = require("semver");
 var svgr = require("@svgr/core").default;
 var resolveConfig = require("@svgr/core").resolveConfig;
+var resolveConfigDir = require("path-dirname");
 
 var upstreamTransformer = null;
 
@@ -50,7 +51,7 @@ module.exports.transform = function(src, filename, options) {
   }
 
   if (filename.endsWith(".svg") || filename.endsWith(".svgx")) {
-    var config = resolveConfig.sync(process.cwd());
+    var config = resolveConfig.sync(resolveConfigDir(filename));
     var defaultsvgrConfig = { native: true };
     var svgrConfig = config
       ? Object.assign({}, defaultsvgrConfig, config)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "@svgr/core": "^4.1.0",
+    "path-dirname": "^1.0.2",
     "semver": "^5.6.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,6 +2165,11 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
+path-dirname@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"


### PR DESCRIPTION
In README.md there is whole section about support for SVGR configuration and a link to documentation:
> Read more about the configuration options: Configuring SVGR
This documentation states that:
> The configuration file will be resolved starting from the location of the file being formatted, and searching up the file tree until a config file is (or isn't) found.

But this doesn't work as expected cause configuration is searched based on process working dir not an asset path. 

This is just a proposition of how it could be changed to work as expected. But it work for me in projects I'm currently working on.

Why it's important? If you want to have different options for different assets it's not possible right now. And generally keeping configuration along with assets is a nice feature IMHO.