### PR TITLE
SVGO: don't convert colors to shorthand format

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ var defaultsvgrConfig = {
       },
       {
         removeUnknownsAndDefaults: false
+      },
+      {
+        convertColors: false
       }
     ]
   }


### PR DESCRIPTION
https://github.com/svg/svgo#what-it-can-do

"convert colors (from rgb() to #rrggbb, from #rrggbb to #rgb)"

fixes #64