### PR TITLE
Replace deprecated StatelessComponent by FC in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If you are using TypeScript, you need to add this to your `declarations.d.ts` fi
 ```ts
 declare module "*.svg" {
   import { SvgProps } from "react-native-svg";
-  const content: React.StatelessComponent<SvgProps>;
+  const content: React.FC<SvgProps>;
   export default content;
 }
 ```


### PR DESCRIPTION
FC = FunctionComponent

Here is the reference of the deprecation:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/70d44c638a55c420ffa1b6793d86b61fffaaf26a/types/react/index.d.ts#L506-L514
