### PR TITLE
Fix app.json configuration for expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,19 @@ If you are using [Expo](https://expo.io/), you also need to add this to `app.jso
   "expo": {
     "packagerOpts": {
       "config": "metro.config.js",
-      "sourceExts": ["js", "jsx", "ts", "tsx", "svg"]
+      "sourceExts": [
+        "expo.ts",
+        "expo.tsx",
+        "expo.js",
+        "expo.jsx",
+        "ts",
+        "tsx",
+        "js",
+        "jsx",
+        "json",
+        "wasm",
+        "svg"
+      ]
     }
   }
 }


### PR DESCRIPTION
Thanks for the library.

Here is a configuration fix for app.json file for expo.

It causes crashes when using with react navigation in android.

ref https://github.com/react-navigation/react-navigation/issues/6919#issuecomment-592093015

fixes https://github.com/kristerkari/react-native-svg-transformer/issues/73
fixes https://github.com/react-navigation/react-navigation/issues/6919