### PR TITLE
Fix README: declaration.d.ts not in root

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you are using [Expo](https://expo.io/), instead of adding the `rn-cli.config.
 
 ### Using TypeScript
 
-If you are using TypeScript, you need to add this to your `declarations.d.ts` file (create one if you don't have one already, but don't put in root):
+If you are using TypeScript, you need to add this to your `declarations.d.ts` file (create one if you don't have one already, but don't put in the root folder of your project):
 
 ```ts
 declare module "*.svg" {

--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ If you are using [Expo](https://expo.io/), instead of adding the `rn-cli.config.
 
 ### Using TypeScript
 
-If you are using TypeScript, you need to add this to your `declarations.d.ts` file (create one if you don't have one already):
+If you are using TypeScript, you need to add this to your `declarations.d.ts` file (create one if you don't have one already, but don't put in root):
 
 ```ts
 declare module "*.svg" {
+  import React from 'react';
   import { SvgProps } from "react-native-svg";
   const content: React.FC<SvgProps>;
   export default content;


### PR DESCRIPTION
Fixes this https://github.com/kristerkari/react-native-svg-transformer/issues/6#issuecomment-491546389
and this https://github.com/kristerkari/react-native-svg-transformer/issues/6#issuecomment-705539985