### PR TITLE
Properly configure metro.config.js for Expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const { getDefaultConfig } = require("expo/metro-config");
 
 module.exports = (async () => {
   const {
-    transformer,
+    transformer: { babelTransformerPath, ...transformer },
     resolver: { sourceExts, assetExts, ...resolver },
     ...config
   } = await getDefaultConfig(__dirname);
@@ -66,7 +66,9 @@ module.exports = (async () => {
     ...config,
     transformer: {
       ...transformer,
-      babelTransformerPath: require.resolve("react-native-svg-transformer")
+      babelTransformerPath: require
+        .resolve('react-native-svg-transformer')
+        .makeTransformer(babelTransformerPath),
     },
     resolver: {
       ...resolver,

--- a/README.md
+++ b/README.md
@@ -58,13 +58,18 @@ const { getDefaultConfig } = require("expo/metro-config");
 
 module.exports = (async () => {
   const {
-    resolver: { sourceExts, assetExts }
+    transformer,
+    resolver: { sourceExts, assetExts, ...resolver },
+    ...config
   } = await getDefaultConfig(__dirname);
   return {
+    ...config,
     transformer: {
+      ...transformer,
       babelTransformerPath: require.resolve("react-native-svg-transformer")
     },
     resolver: {
+      ...resolver,
       assetExts: assetExts.filter(ext => ext !== "svg"),
       sourceExts: [...sourceExts, "svg"]
     }


### PR DESCRIPTION
Fixes #141 by updating the documentation for metro.config.js configuration in Expo environments

# Why?

Currently, the metro config is not properly configured and this causes the following error from expo:

```
It looks like that you are using a custom metro.config.js that does not extend @expo/metro-config.
This can result in unexpected and hard to debug issues, like missing assets in the production bundle.
We recommend you to abort, fix the metro.config.js, and try again.
```

# Test Plan

Update the configuration in a project
Run eas build and ensure that no warning is emitted