### PR TITLE
Support both versions of React Native Metro Babel Transformer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,18 @@
 const { resolveConfig, transform } = require("@svgr/core");
 const resolveConfigDir = require("path-dirname");
-const upstreamTransformer = require("metro-react-native-babel-transformer");
+/**
+ * `metro-react-native-babel-transformer` has recently been migrated to the React Native
+ * repository and published under the `@react-native/metro-babel-transformer` name.
+ * The new package is default on `react-native` >= 0.73.0, so we need to conditionally load it.
+ */
+const upstreamTransformer = function() {
+  try {
+    const resolver = require("@react-native/metro-babel-transformer");
+    return resolver;
+  } catch (error) {
+    return require("metro-react-native-babel-transformer");
+  }
+}();
 
 const defaultSVGRConfig = {
   native: true,


### PR DESCRIPTION
The `metro-react-native-babel-transformer` package has been recently migrated to the [React Native monorepo](https://github.com/facebook/react-native/tree/main/packages/react-native-babel-transformer) and published/required under the `@react-native/metro-babel-transformer` alias.

Starting with `react-native@0.73.0`, the new package is [loaded by default](https://github.com/facebook/react-native/blob/19945ad83b12c03d8b0931fd1a02bebabbc1a96b/packages/metro-config/package.json#L23), which makes the current implementation break when starting the metro bundler.

To solve this, a simple `try/catch` block that loads the new package and fallbacks to the previous one in case it doesn't exist should suffice.