### PR TITLE
Attempt to load Expo's upstream transformer if it's available

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,25 @@
 const { resolveConfig, transform } = require("@svgr/core");
 const resolveConfigDir = require("path-dirname");
+
 /**
  * `metro-react-native-babel-transformer` has recently been migrated to the React Native
  * repository and published under the `@react-native/metro-babel-transformer` name.
  * The new package is default on `react-native` >= 0.73.0, so we need to conditionally load it.
+ *
+ * Additionally, Expo v50.0.0 has begun using @expo/metro-config/babel-transformer as its upstream transformer.
+ * To avoid breaking projects, we should prioritze that package if it is available.
  */
-const upstreamTransformer = (function () {
+const upstreamTransformer = (() => {
   try {
-    const resolver = require("@react-native/metro-babel-transformer");
-    return resolver;
+    return require("@expo/metro-config/babel-transformer");
   } catch (error) {
-    return require("metro-react-native-babel-transformer");
+    try {
+      return require("@react-native/metro-babel-transformer");
+    } catch (error) {
+      return require("metro-react-native-babel-transformer");
+    }
   }
-}());
+})();
 
 const defaultSVGRConfig = {
   native: true,


### PR DESCRIPTION
Expo v50 now uses [its own upstream transformer](https://github.com/expo/expo/blob/ef18f05832c2d62b66ba4a0d345348f4e4ea5c37/docs/pages/versions/v50.0.0/config/metro.mdx#L374-L391) instead of `metro-react-native-babel-transformer`. 

This causes the error in the Metro configuration, as the library currently attempts to use `metro-react-native-babel-transformer` as the upstream.

```
node_modules/expo-router/_ctx.ios.js: Expected `fromDir` to be of type `string`, got `undefined`` to be thrown when attempting to use `react-native-svg-transformer`
```

To resolve this, we can attempt to first load Expo's transformer and then attempt loading `metro-react-native-babel-transformer`.