### PR TITLE
Edit metro reference link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const { assetExts, sourceExts } = defaultConfig.resolver;
 
 /**
  * Metro configuration
- * https://facebook.github.io/metro/docs/configuration
+ * https://reactnative.dev/docs/metro
  *
  * @type {import('metro-config').MetroConfig}
  */


### PR DESCRIPTION
## Issue

When the native version of React was updated to 0.74.0, the link in the metro.config.js file changed.

<img width="706" alt="스크린샷 2024-04-30 오후 6 52 54" src="https://github.com/kristerkari/react-native-svg-transformer/assets/54518925/ec3ffa8b-5524-4e24-ac54-e84d854d73fe">
