### PR TITLE
Forward all parameters of transform to the upstream transfoemer

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ const defaultSVGRConfig = {
   }
 };
 
-module.exports.transform = async ({ src, filename, options }) => {
+module.exports.transform = async ({ src, filename, ...rest }) => {
   if (filename.endsWith(".svg")) {
     const config = await resolveConfig(resolveConfigDir(filename));
     const svgrConfig = config
@@ -52,8 +52,8 @@ module.exports.transform = async ({ src, filename, options }) => {
     return upstreamTransformer.transform({
       src: await transform(src, svgrConfig),
       filename,
-      options
+      ...rest
     });
   }
-  return upstreamTransformer.transform({ src, filename, options });
+  return upstreamTransformer.transform({ src, filename, ...rest });
 };


### PR DESCRIPTION
This PR fixes an issue where `plugins` parameter is not forwarded properly to the original transformer when svg-transformer is configured.

See https://github.com/facebook/react-native/blob/main/packages/react-native-babel-transformer/src/index.js#L184 for the full list of attributes of the object that upstream transformer takes. And specifically note that except from `src`, `filename` and `options`, also `plugins` is listed there.

Before this PR the list or attributes was limited to explicitely listed `src`, `filename`, and `options`, while `plugins` was missing. Since this transformer only uses `src` and `filename` directly, we replace the remaining part rest spread and forward it to the upstream transformer. This solution also makes this implementation more future proof in case new parameters are added.