### PR TITLE
fix: do not try to resolve RN transformer in expo projects

### DIFF
--- a/expo/index.js
+++ b/expo/index.js
@@ -1,3 +1,3 @@
-const { createTransformer, expoTransformer } = require("../index.js");
+const { createTransformer, getExpoTransformer } = require("../index.js");
 
-module.exports.transform = createTransformer(expoTransformer);
+module.exports.transform = createTransformer(getExpoTransformer());

--- a/index.js
+++ b/index.js
@@ -6,21 +6,21 @@ const resolveConfigDir = require("path-dirname");
  * repository and published under the `@react-native/metro-babel-transformer` name.
  * The new package is default on `react-native` >= 0.73.0, so we need to conditionally load it.
  */
-const reactNativeTransformer = (() => {
+const getReactNativeTransformer = () => {
   try {
     return require("@react-native/metro-babel-transformer");
   } catch (error) {
     return require("metro-react-native-babel-transformer");
   }
-})();
+};
 
-const expoTransformer = (() => {
+const getExpoTransformer = () => {
   try {
     return require("@expo/metro-config/babel-transformer");
   } catch (error) {
     return null;
   }
-})();
+};
 
 const defaultSVGRConfig = {
   native: true,
@@ -62,14 +62,14 @@ function createTransformer(transformer) {
 }
 
 module.exports = {
-  reactNativeTransformer,
-  expoTransformer,
+  getReactNativeTransformer,
+  getExpoTransformer,
   createTransformer,
   transform: createTransformer(
     /*
      * Expo v50.0.0 has begun using @expo/metro-config/babel-transformer as its upstream transformer.
      * To avoid breaking projects, we should prioritze that package if it is available.
      **/
-    expoTransformer || reactNativeTransformer
+    getExpoTransformer() || getReactNativeTransformer()
   )
 };

--- a/react-native/index.js
+++ b/react-native/index.js
@@ -1,3 +1,3 @@
-const { createTransformer, reactNativeTransformer } = require("../index.js");
+const { createTransformer, getReactNativeTransformer } = require("../index.js");
 
-module.exports.transform = createTransformer(reactNativeTransformer);
+module.exports.transform = createTransformer(getReactNativeTransformer());


### PR DESCRIPTION
Hello,

This should fix #410 

Self executed function make us try to resolve one of the React Native transformer (`@react-native/metro-babel-transformer` or the legacy `metro-react-native-babel-transformer`) even for Expo projects

If the project does not contain any of the 2 RN transformer, this make transforming fail

This change make sure we do not try to resolve those packages if we don't need them

Thanks!